### PR TITLE
open pickle files in 'rb' mode

### DIFF
--- a/notebooks/tensorflow/Tensorflow-1-NotMNIST.ipynb
+++ b/notebooks/tensorflow/Tensorflow-1-NotMNIST.ipynb
@@ -449,7 +449,7 @@
     }
    ],
    "source": [
-    "file = open(train_datasets[0])\n",
+    "file = open(train_datasets[0], 'rb')\n",
     "train_A = pickle.load(file)\n",
     "train_A.shape"
    ]
@@ -538,11 +538,11 @@
    "source": [
     "print('Checking number of images per class...')\n",
     "for letter in train_datasets:\n",
-    "    file = open(letter)\n",
+    "    file = open(letter, 'rb')\n",
     "    dataset = pickle.load(file)\n",
     "    print(letter + ' size: ' + str(dataset.shape[0]))\n",
     "for letter in test_datasets:\n",
-    "    file = open(letter)\n",
+    "    file = open(letter, 'rb')\n",
     "    dataset = pickle.load(file)\n",
     "    print(letter + ' size: ' + str(dataset.shape[0]))"
    ]


### PR DESCRIPTION
At lieast with the latest python3 and jupyter notebook, it doesn't work if you don't use 'rb' when opening the pickle files